### PR TITLE
Update loading style

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ledgerhq/live-app-sdk": "^0.8.1",
-    "@ledgerhq/react-ui": "^0.8.1",
+    "@ledgerhq/react-ui": "0.8.1",
     "modern-normalize": "^1.1.0",
     "next": "12.2.4",
     "react": "18.2.0",

--- a/src/WebBrowser.tsx
+++ b/src/WebBrowser.tsx
@@ -1,3 +1,4 @@
+import { Button, Flex, Text } from "@ledgerhq/react-ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import CSSTransition from "react-transition-group/CSSTransition";
 import styled from "styled-components";
@@ -264,15 +265,31 @@ export const WebBrowser = ({
       <Container>
         <CSSTransition in={clientLoaded} timeout={300} classNames="overlay">
           <Overlay>
-            <Loader>
-              {!connected
-                ? "Connecting ..."
-                : fetchingAccounts
-                ? "Loading accounts ..."
-                : accounts.length === 0
-                ? "You don't have any accounts"
-                : `Loading ${webAppName} ...`}
-            </Loader>
+            {!connected ? (
+              <Loader>
+                <Text color="neutral.c100">{"Connecting ..."}</Text>
+              </Loader>
+            ) : fetchingAccounts ? (
+              <Loader>
+                <Text color="neutral.c100">{"Loading accounts ..."}</Text>
+              </Loader>
+            ) : accounts.length === 0 ? (
+              <Flex flexDirection="column" alignItems="center">
+                <Text mb={6} color="neutral.c100">
+                  {"You need an account to access this app."}
+                </Text>
+                <Button onClick={requestAccount} variant="main">
+                  {"Add Account"}
+                </Button>
+              </Flex>
+            ) : (
+              <Loader>
+                <Text
+                  variant="h5"
+                  color="neutral.c100"
+                >{`Loading ${webAppName} ...`}</Text>
+              </Loader>
+            )}
           </Overlay>
         </CSSTransition>
         {connected && webAppUrl ? (


### PR DESCRIPTION
Make the loading screen style consistent with the one currently in place on [eth-dapp-browser](https://github.com/LedgerHQ/eth-dapp-browser) side

<details open>
<summary>Before</summary>

![before](https://user-images.githubusercontent.com/9203826/198641548-36f62393-fb2b-4292-b29c-2cbba1a25440.png)


</details>

<details open>
<summary>After</summary>

![after](https://user-images.githubusercontent.com/9203826/198641701-9de5ef97-5c4f-4968-8bae-11488c2bab5f.png)

</details>